### PR TITLE
Refactored Uptime Class to be more SOLID and DRY

### DIFF
--- a/src/Statsy.php
+++ b/src/Statsy.php
@@ -1,25 +1,44 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: tomrouse
- * Date: 16/04/2017
- * Time: 16:06
- */
 
 namespace Statsy;
 
 include 'autoload.php';
 
-
+/**
+ * Class Statsy
+ *
+ * @package Statsy
+ */
 class Statsy
 {
-
+    /**
+     * @var Memory
+     */
     protected $memory;
+
+    /**
+     * @var Disk
+     */
     protected $disk;
+
+    /**
+     * @var Cpu
+     */
     protected $cpu;
+
+    /**
+     * @var Uptime
+     */
     protected $uptime;
 
-
+    /**
+     * Statsy constructor.
+     *
+     * @param Memory $memory
+     * @param Cpu $cpu
+     * @param Disk $disk
+     * @param Uptime $uptime
+     */
     public function __construct(Memory $memory, Cpu $cpu, Disk $disk, Uptime $uptime)
     {
         $this->memory = $memory;
@@ -161,25 +180,25 @@ class Statsy
 
     public function uptimeDays()
     {
-        return $this->uptime->days();
+        return $this->uptime->getUptime()->getTimeString();
     }
 
 
     public function uptimeHours()
     {
-        return $this->uptime->hours();
+        return $this->uptime->getUptime()->getTimeString(true, true);
     }
 
 
-    public function uptimeMins()
+    public function uptimeMinutes()
     {
-        return $this->uptime->mins();
+        return $this->uptime->getUptime()->getTimeString(true, true, true);
     }
 
 
-    public function uptimeSecs()
+    public function uptimeSeconds()
     {
-        return $this->uptime->secs();
+        return $this->uptime->getUptime()->getTimeString(true, true, true, true);
     }
 
     //Ip

--- a/src/StatsyBase.php
+++ b/src/StatsyBase.php
@@ -8,17 +8,31 @@
 
 namespace Statsy;
 
-
+/**
+ * Class StatsyBase
+ *
+ * @package Statsy
+ */
 abstract class StatsyBase
 {
-
+    /**
+     * Performs a round on the seconds
+     *
+     * @param $value
+     * @param $precision
+     * @return float|int
+     */
     protected function round_up ( $value, $precision )
     {
         $pow = pow ( 10, $precision );
         return ( ceil ( $pow * $value ) + ceil ( $pow * $value - ceil ( $pow * $value ) ) ) / $pow;
     }
 
-
+    /**
+     * @param $input
+     * @param $conversion
+     * @return float|int
+     */
     protected function convert($input, $conversion)
     {
         if ($conversion == 'mb') {
@@ -31,7 +45,11 @@ abstract class StatsyBase
         }
     }
 
-
+    /**
+     * @param $dataValue
+     * @param $memoryValue
+     * @return float|int
+     */
     protected function returnCalculator($dataValue, $memoryValue)
     {
         if ($memoryValue == '') {
@@ -51,6 +69,9 @@ abstract class StatsyBase
         }
     }
 
+    /**
+     * @return mixed
+     */
     public static function ip()
     {
         return $_SERVER['SERVER_ADDR'];

--- a/src/Uptime.php
+++ b/src/Uptime.php
@@ -1,68 +1,147 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: tomrouse
- * Date: 14/04/2017
- * Time: 20:34
- */
 
 namespace Statsy;
 
-
+/**
+ * Class Uptime
+ *
+ * This class is used to get the current uptime of the system. When you make use of this class
+ * you have to pass the file path to your systems uptime file. You can then use our fluent
+ * interface to access various pieces of the application.
+ *
+ * @package Statsy
+ */
 class Uptime extends StatsyBase
 {
-
-    const FILE = '/proc/uptime';
-
+    /**
+     * @var int
+     */
     private $days;
+
+    /**
+     * @var int
+     */
     private $hours;
-    private $mins;
-    private $secs;
 
+    /**
+     * @var int
+     */
+    private $minutes;
 
-    private function getUptime()
+    /**
+     * @var int
+     */
+    private $seconds;
+
+    /**
+     * @var string
+     */
+    private $uptimeFile;
+
+    /**
+     * @var Resource
+     */
+    private $handle;
+
+    /**
+     * Uptime constructor.
+     *
+     * @param $uptimeFile
+     */
+    public function __construct($uptimeFile)
     {
-        $str   = @file_get_contents('/proc/uptime');
-        $num   = floatval($str);
-
-        $this->secs  = fmod($num, 60); $num = intdiv($num, 60);
-        $this->mins  = $num % 60;         $num = intdiv($num, 60);
-        $this->hours = $num % 24;         $num = intdiv($num, 24);
-        $this->days  = $num;
+        $this->uptimeFile = $uptimeFile;
+        $this->handle     = fopen($this->uptimeFile, 'r');
     }
 
-
-    public function days()
+    /**
+     * Gets the current uptime of the server
+     *
+     * @return Uptime
+     */
+    public function getUptime()
     {
-        $this->getUptime();
+        $str           = ($this->handle !== false) ? stream_get_contents($this->handle) : 0;
+        $num           = (float)$str;
+        $this->seconds = fmod($num, 60);
+        $num           = intdiv($num, 60);
+        $this->minutes = $num % 60;
+        $num           = intdiv($num, 60);
+        $this->hours   = $num % 24;
+        $num           = intdiv($num, 24);
+        $this->days    = $num;
 
-        return $this->days . "&nbsp" . "Days" . "&nbsp";
+        return $this;
     }
 
+    /**
+     * Returns a time string with the wanted information inside of it
+     *
+     * @param bool $days
+     * @param bool $hours
+     * @param bool $minutes
+     * @param bool $seconds
+     * @return string
+     */
+    public function getTimeString(
+        $days    = true,
+        $hours   = false,
+        $minutes = false,
+        $seconds = false
+    ) {
+        $timeString = ($days    === true) ? $this->days()                  : '';
+        $timeString = ($hours   === true) ? $timeString . $this->hours()   : $timeString;
+        $timeString = ($minutes === true) ? $timeString . $this->minutes() : $timeString;
+        $timeString = ($seconds === true) ? $timeString . $this->seconds() : $timeString;
 
-    public function hours()
-    {
-        $this->getUptime();
-
-        return $this->days . "&nbsp" . "Days" . "&nbsp" .$this->hours . "&nbsp" . "Hours" . "&nbsp";
+        return $timeString;
     }
 
-
-    public function mins()
+    /**
+     * Returns the days in string form
+     *
+     * @return string
+     */
+    private function days()
     {
-        $this->getUptime();
-
-        return $this->days . "&nbsp" . "Days" . "&nbsp" . $this->hours . "&nbsp" . "Hours" . "&nbsp" . $this->mins . "&nbsp" . "Mins" . "&nbsp";
+        return $this->days . "&nbsp;" . "Days" . "&nbsp;";
     }
 
-
-    public function secs()
+    /**
+     * Returns the days in string form
+     *
+     * @return string
+     */
+    private function hours()
     {
-        $this->getUptime();
-
-        return $this->days . "&nbsp" . "Days" . "&nbsp" . $this->hours . "&nbsp" . "Hours" . "&nbsp" . $this->mins . "&nbsp" . "Mins" . "&nbsp" . StatsyBase::round_up($this->secs, 0) . "&nbsp" . "Secs" . "&nbsp";
+        return $this->hours . "&nbsp;" . "Hours" . "&nbsp;";
     }
 
+    /**
+     * Returns the minuets in string form
+     *
+     * @return string
+     */
+    private function minutes()
+    {
+        return $this->minutes . "&nbsp;" . "Mins" . "&nbsp;";
+    }
 
+    /**
+     * Returns the seconds in string form
+     *
+     * @return string
+     */
+    private function seconds()
+    {
+        return StatsyBase::round_up($this->seconds, 0) . "&nbsp;" . "Secs" . "&nbsp;";
+    }
 
+    /**
+     * Closes the file handler for uptime
+     */
+    public function __destruct()
+    {
+        fclose($this->handle);
+    }
 }


### PR DESCRIPTION
I did a good bit of refactoring on your uptime class.

Instead of having a set of methods that build into a monolithic string, I wrote it in a way where you can use a single method to get all permutations of the string.

It works like this:

```php
<?php

$uptime = new \Statsy\Uptime();

$justDays = $uptime->getUptime()->getTimeString();
$justHours = $uptime->getUptime()->getTimeString(false, true);
$justMinutes = $uptime->getUptime()->getTimeString(false, false, true);
$justSeconds = $uptime->getUptime()->getTimeString(false, false, false, true);
```

The toggles can be used in anyway to get any permutation of the string.